### PR TITLE
Feature/flow 2849 - Bundle svgs in ui-offline separately (non hotfix version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-motion": "0.5.2",
     "react-test-renderer": "16.8.6",
     "react-transition-group": "1.2.1",
+    "react-svg-loader": "^3.0.3",
     "remove-files-webpack-plugin": "^1.1.3",
     "script-loader": "^0.7.2",
     "sinon": "3.2.1",

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -118,6 +118,10 @@ module.exports = (env) => ({
             // bundle fonts
             {
                 test: /\.(woff|woff2|eot|ttf|svg|otf)$/,
+                exclude: [
+                    path.resolve(__dirname, `${repoPaths.uiOffline}/icons/Offline.svg`),
+                    path.resolve(__dirname, `${repoPaths.uiOffline}/icons/Online.svg`),
+                ],
                 use: [
                     {
                         loader: 'file-loader',
@@ -132,6 +136,10 @@ module.exports = (env) => ({
             // bundle images
             {
                 test: /\.(png|svg|jpg|gif)$/,
+                exclude: [
+                    path.resolve(__dirname, `${repoPaths.uiOffline}/icons/Offline.svg`),
+                    path.resolve(__dirname, `${repoPaths.uiOffline}/icons/Online.svg`),
+                ],
                 use: [
                     {
                         loader: 'file-loader',
@@ -192,6 +200,19 @@ module.exports = (env) => ({
                     { loader: 'extract-loader' },
                     { loader: 'css-loader' },
                     { loader: 'less-loader' },
+                ],
+            },
+            // bundle offline icons
+            {
+                test: /\.svg$/,
+                include: [
+                    path.resolve(__dirname, `${repoPaths.uiOffline}/icons/Offline.svg`),
+                    path.resolve(__dirname, `${repoPaths.uiOffline}/icons/Online.svg`),
+                ],
+                use: [
+                    {
+                        loader: 'react-svg-loader',
+                    },
                 ],
             },
         ],


### PR DESCRIPTION
The file-loader isn't loading the svgs as the code expects.
So I'm using the recat-svg-loader and telling the other svg loaders to leave the offline svgs alone.
Tested locally and it loads the icon now and the rest of the page doesn't crash.