### PR TITLE
Feature/flow 2828

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@
 ## Installing dependencies
 
 If dependencies have not been installed yet, install them in the top level 
-monorepo `ui-runtime` and in each of the subrepos (`ui-core`, `ui-bootstrap`, ...)
+monorepo `ui-runtime`
 with:
 
 ```shell script
 # top level monorepo
-npm install
-
-# for each subrepo
-cd <subrepo>
 npm install
 ```
 
@@ -58,17 +54,11 @@ To run tests on all subrepos use:
 npm test
 ```
 
-To run tests on individual subrepos use:
+To run tests on ui-core only use:
 
 ```shell script
-# ui-bootstrap
-npm run test:bootstrap
-
 # ui-core
-npm run test:core
-
-# ui-offline
-npm run test:offline
+npm test:core
 ```
 
 All listed commands are defined in the top-level `package.json` and should be 

--- a/ui-bootstrap/__tests__/items-container.test.tsx
+++ b/ui-bootstrap/__tests__/items-container.test.tsx
@@ -1157,7 +1157,7 @@ describe('ItemsContainer component behaviour', () => {
         // start off with mock entry 1 selected
         componentWrapper = manyWhoMount({ objectData: minimalSelectionTestData, selectedData: mockEntry1, isMultiSelect: true });
 
-        // test selecting a different entry and that is gets appended
+        // test selecting a different entry and that it gets appended
         componentWrapper.instance().select(mockEntry2[0].internalId, false);
         expect(setComponentSpy).toHaveBeenCalledWith(expect.anything(), { objectData: mockBothEntries }, expect.anything(), expect.anything());
     });

--- a/ui-bootstrap/__tests__/items-container.test.tsx
+++ b/ui-bootstrap/__tests__/items-container.test.tsx
@@ -1003,4 +1003,79 @@ describe('ItemsContainer component behaviour', () => {
         expect(() => componentWrapper.setState({ search: null, sortedBy: 'test', sortedIsAscending: true })).not.toThrow();
     });
 
+    // test('Single selection adds and removes an item by internalId correctly to the list of selections', () => {
+    //     // test adding by string
+
+    //     // test selecting another item by object
+
+    //     // test removing by string
+
+    //     // test removing by object
+    //     componentWrapper = manyWhoMount();
+
+    //     const hasBulkActions = ItemsContainer.prototype.areBulkActionsDefined([
+    //         { isBulkAction: false },
+    //         { isBulkAction: false },
+    //     ]);
+
+    //     expect(hasBulkActions).toBe(false);
+    // });
+
+    // test('Single selection adds and removes an item by externalId correctly to the list of selections', () => {
+    //     // test adding by string
+
+    //     // test selecting another item by object
+
+    //     // test removing by string
+
+    //     // test removing by object
+        
+    //     componentWrapper = manyWhoMount();
+
+    //     const hasBulkActions = ItemsContainer.prototype.areBulkActionsDefined([
+    //         { isBulkAction: false },
+    //         { isBulkAction: false },
+    //     ]);
+
+    //     expect(hasBulkActions).toBe(false);
+    // });
+
+    // test('Multiselect selection adds and removes an item by internalId correctly to the list of selections', () => {
+    //     // test adding by string
+
+    //     // test selecting another item by object
+
+    //     // test removing by string
+
+    //     // test removing by object
+        
+    //     componentWrapper = manyWhoMount();
+
+    //     const hasBulkActions = ItemsContainer.prototype.areBulkActionsDefined([
+    //         { isBulkAction: false },
+    //         { isBulkAction: false },
+    //     ]);
+
+    //     expect(hasBulkActions).toBe(false);
+    // });
+
+    // test('Multiselect selection adds and removes an item by externalId correctly to the list of selections', () => {
+    //     // test adding by string
+
+    //     // test selecting another item by object
+
+    //     // test removing by string
+
+    //     // test removing by object
+        
+    //     componentWrapper = manyWhoMount();
+
+    //     const hasBulkActions = ItemsContainer.prototype.areBulkActionsDefined([
+    //         { isBulkAction: false },
+    //         { isBulkAction: false },
+    //     ]);
+
+    //     expect(hasBulkActions).toBe(false);
+    // });
+
 });

--- a/ui-bootstrap/__tests__/items-container.test.tsx
+++ b/ui-bootstrap/__tests__/items-container.test.tsx
@@ -1088,9 +1088,10 @@ describe('ItemsContainer component behaviour', () => {
         mockEntry2.isSelected = true;
         mockEntry2 = [mockEntry2];
 
+        // start off with mock entry 1 selected
         componentWrapper = manyWhoMount({ objectData: minimalSelectionTestData, selectedData: mockEntry1 });
 
-        // test selecting a different entry
+        // test selecting a different entry and that selection is swapped to entry 2
         componentWrapper.instance().select(mockEntry2[0].internalId, false);
         expect(setComponentSpy).toHaveBeenCalledWith(expect.anything(), { objectData: mockEntry2 }, expect.anything(), expect.anything());
     });
@@ -1137,23 +1138,28 @@ describe('ItemsContainer component behaviour', () => {
         expect.assertions(12);
     });
 
-    // test('Multiselect selection adds and removes an item by externalId correctly to the list of selections', () => {
-    //     // test adding by string
+    test('Multiselect selection selecting another item adds to the list of selected items', () => {
+        globalAny.window.manywho.utils.isEqual = (item1, item2): boolean => item1 === item2;
 
-    //     // test selecting another item by object
+        const setComponentSpy = jest.fn();
+        globalAny.window.manywho.state.setComponent = setComponentSpy;
 
-    //     // test removing by string
+        let mockEntry1 = JSON.parse(JSON.stringify(minimalSelectionTestData[0]));
+        mockEntry1.isSelected = true;
+        mockEntry1 = [mockEntry1];
 
-    //     // test removing by object
-        
-    //     componentWrapper = manyWhoMount();
+        let mockEntry2 = JSON.parse(JSON.stringify(minimalSelectionTestData[1]));
+        mockEntry2.isSelected = true;
+        mockEntry2 = [mockEntry2];
 
-    //     const hasBulkActions = ItemsContainer.prototype.areBulkActionsDefined([
-    //         { isBulkAction: false },
-    //         { isBulkAction: false },
-    //     ]);
+        const mockBothEntries = [mockEntry1[0], mockEntry2[0]];
 
-    //     expect(hasBulkActions).toBe(false);
-    // });
+        // start off with mock entry 1 selected
+        componentWrapper = manyWhoMount({ objectData: minimalSelectionTestData, selectedData: mockEntry1, isMultiSelect: true });
+
+        // test selecting a different entry and that is gets appended
+        componentWrapper.instance().select(mockEntry2[0].internalId, false);
+        expect(setComponentSpy).toHaveBeenCalledWith(expect.anything(), { objectData: mockBothEntries }, expect.anything(), expect.anything());
+    });
 
 });

--- a/ui-bootstrap/__tests__/items-container.test.tsx
+++ b/ui-bootstrap/__tests__/items-container.test.tsx
@@ -1032,7 +1032,7 @@ describe('ItemsContainer component behaviour', () => {
         expect(() => componentWrapper.setState({ search: null, sortedBy: 'test', sortedIsAscending: true })).not.toThrow();
     });
 
-    test('Single selection adds and removes an item by internalId or externalId correctly to the list of selections', () => {
+    test('Single selection adds and removes a selected item by internalId or externalId', () => {
         globalAny.window.manywho.utils.isEqual = (item1, item2): boolean => item1 === item2;
 
         const setComponentSpy = jest.fn();
@@ -1074,7 +1074,28 @@ describe('ItemsContainer component behaviour', () => {
         expect.assertions(12);
     });
 
-    test('Multiselect selection selecting one at a time adds and removes an item by internalId or externalId correctly to the list of selections', () => {
+    test('Single selection selecting another item changes the selected item to that', () => {
+        globalAny.window.manywho.utils.isEqual = (item1, item2): boolean => item1 === item2;
+
+        const setComponentSpy = jest.fn();
+        globalAny.window.manywho.state.setComponent = setComponentSpy;
+
+        let mockEntry1 = JSON.parse(JSON.stringify(minimalSelectionTestData[0]));
+        mockEntry1.isSelected = true;
+        mockEntry1 = [mockEntry1];
+
+        let mockEntry2 = JSON.parse(JSON.stringify(minimalSelectionTestData[1]));
+        mockEntry2.isSelected = true;
+        mockEntry2 = [mockEntry2];
+
+        componentWrapper = manyWhoMount({ objectData: minimalSelectionTestData, selectedData: mockEntry1 });
+
+        // test selecting a different entry
+        componentWrapper.instance().select(mockEntry2[0].internalId, false);
+        expect(setComponentSpy).toHaveBeenCalledWith(expect.anything(), { objectData: mockEntry2 }, expect.anything(), expect.anything());
+    });
+
+    test('Multiselect selection selecting one at a time adds and removes a selected item by internalId or externalId', () => {
         globalAny.window.manywho.utils.isEqual = (item1, item2): boolean => item1 === item2;
 
         const setComponentSpy = jest.fn();

--- a/ui-bootstrap/js/components/items-container.tsx
+++ b/ui-bootstrap/js/components/items-container.tsx
@@ -276,15 +276,22 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
         const model = manywho.model.getComponent(this.props.id, this.props.flowKey);
         const state = manywho.state.getComponent(this.props.id, this.props.flowKey);
 
+        // We use the externalId when possible,
+        // because for service data, the internalId is randomly generated
+        // and not a reliable indicator of what is selected
+        const getId = (anItem): string => anItem.externalId || anItem.internalId;
+
         let selectedItems = (state.objectData || [])
-            .filter(anItem => anItem.isSelected)
-            .map(anItem => anItem);
+            .filter((anItem) => anItem.isSelected)
+            .map((anItem) => anItem);
 
         let selectedItem = null;
 
         if (typeof item === 'string') {
+            // In this case 'item' is the internalId of the selected item
+            // So we need to filter by this to find the selected actual selected item
             [selectedItem] = model.objectData.filter(
-                objectData => manywho.utils.isEqual(objectData.internalId, item, true),
+                (objectData) => manywho.utils.isEqual(objectData.internalId, item, true),
             );
         } else if (typeof item === 'object') {
             selectedItem = item;
@@ -294,7 +301,7 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
         selectedItem = JSON.parse(JSON.stringify(selectedItem));
 
         const isSelected = selectedItems.filter(
-            anItem => anItem.internalId === selectedItem.internalId,
+            (anItem) => getId(anItem) === getId(selectedItem),
         ).length > 0;
 
         selectedItem.isSelected = !isSelected;
@@ -303,7 +310,7 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
             if (selectedItem.isSelected) {
                 selectedItems.push(selectedItem);
             } else {
-                selectedItems = selectedItems.filter(anItem => !manywho.utils.isEqual(anItem.internalId, selectedItem.internalId, true));
+                selectedItems = selectedItems.filter((anItem) => !manywho.utils.isEqual(getId(anItem), getId(selectedItem), true));
             }
         } else if (selectedItem.isSelected) {
             selectedItems = [selectedItem];

--- a/ui-bootstrap/js/components/items-container.tsx
+++ b/ui-bootstrap/js/components/items-container.tsx
@@ -288,8 +288,8 @@ class ItemsContainer extends React.Component<IComponentProps, IItemsContainerSta
         let selectedItem = null;
 
         if (typeof item === 'string') {
-            // In this case 'item' is the internalId of the selected item
-            // So we need to filter by this to find the selected actual selected item
+            // In this case the string 'item' is the internalId of the selected item
+            // so we have to use internalId to find the selected item
             [selectedItem] = model.objectData.filter(
                 (objectData) => manywho.utils.isEqual(objectData.internalId, item, true),
             );

--- a/ui-offline/README.md
+++ b/ui-offline/README.md
@@ -131,11 +131,16 @@ npm run offline -- --username=example@example.com --password=example --flow=abc1
 
 This will create a metadata.js file in `../ui-html5/build/js`.
 
-To include the offline components you will need to add the following references to debug.html in the ui-html5 repo:
+To include the offline components you will need to add the following references to index.html in the parent ui-runtime repo:
 
 ```
 <script src="build/js/metadata.js"></script>
-<script src="build/js/flow-offline.js"></script>
+```
+
+And add 'offline' to the requires list to become:
+
+```
+requires: ['core', 'bootstrap3', 'offline'],
 ```
 
 ### Running Unit Tests


### PR DESCRIPTION
I am now using externalId as a preference over internalId when matching selected items in a table.

This is because internalIds from a service are completely random and not a good indicator of what an item actually is.

I tested this offline and the fallback to externalId worked correctly and I was able to select things created offline (so they only had internalIds) as well as things created online.

When I synced back online, all selections seem to be reset anyway, I tested this in the previous release too and it is the same, so any concerns over selections with offline only data being kept after resyncing are not necessary.