### PR TITLE
Feature/flow 2921

### DIFF
--- a/ui-bootstrap/__tests__/chart-base.test.tsx
+++ b/ui-bootstrap/__tests__/chart-base.test.tsx
@@ -20,6 +20,7 @@ describe('ChartBase component behaviour', () => {
     let componentWrapper;
 
     const globalAny: any = global;
+    globalAny.window.manywho.settings.global = jest.fn();
 
     function manyWhoMount(
         // props
@@ -62,6 +63,34 @@ describe('ChartBase component behaviour', () => {
         componentWrapper = manyWhoMount();
         expect(globalAny.window.manywho.component.register)
             .toHaveBeenCalledWith('mw-chart-base', ChartBase);
+    });
+
+    test('Component runs updateChart on load', () => {
+        globalAny.window.manywho.settings.global.mockClear();
+        componentWrapper = manyWhoMount({ isVisible: true });
+
+        expect(globalAny.window.manywho.settings.global)
+            .toHaveBeenCalledTimes(4);
+    });
+
+    test('Component doesn\'t run updateChart when turning invisible', () => {
+        componentWrapper = manyWhoMount({ isVisible: true });
+
+        globalAny.window.manywho.settings.global.mockClear();
+        componentWrapper.setProps({ isVisible: false });
+
+        expect(globalAny.window.manywho.settings.global)
+            .toHaveBeenCalledTimes(0);
+    });
+
+    test('Component runs updateChart when turning visible', () => {
+        componentWrapper = manyWhoMount({ isVisible: false });
+
+        globalAny.window.manywho.settings.global.mockClear();
+        componentWrapper.setProps({ isVisible: true });
+        
+        expect(globalAny.window.manywho.settings.global)
+            .toHaveBeenCalledTimes(4);
     });
 
 });

--- a/ui-bootstrap/js/components/chart-base.tsx
+++ b/ui-bootstrap/js/components/chart-base.tsx
@@ -164,7 +164,7 @@ class ChartBase extends React.Component<IChartBaseProps, null> {
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {
-        if ((this.props.isLoading && !prevProps.isLoading) || !equals(this.props.objectData, prevProps.objectData)) {
+        if (!equals(this.props, prevProps)) {
             this.updateChart();
         }
     }

--- a/ui-bootstrap/js/components/chart-base.tsx
+++ b/ui-bootstrap/js/components/chart-base.tsx
@@ -163,7 +163,7 @@ class ChartBase extends React.Component<IChartBaseProps, null> {
         this.updateChart();
     }
 
-    componentDidUpdate(prevProps, prevState, snapshot) {
+    componentDidUpdate(prevProps) {
         if (!equals(this.props, prevProps)) {
             this.updateChart();
         }


### PR DESCRIPTION
The bug: When the isVisible prop changed from false to true, the condition in the previous componentDidUpdate was not allowing a rerender, as that condition only checked for objectData changes.

In the previous componentDidUpdate also was a condition regarding isLoading, but, that has been incorrect ever since https://github.com/manywho/ui-runtime/commit/675cf29078ecd934211b4cffc5c4400a7af109b7 where nextProps was changed to prevProps and the condition was changed from:
this.props.isLoading && !nextProps.isLoading
to
this.props.isLoading && !prevProps.isLoading
without considering that now the two props now mean the opposite of what they used to.

I've taken this out as it may have been protecting something long ago, but since it's been broken in that commit and doesn't make sense anymore there is no point in keeping it.

Now we reload the chart whenever the props change.