### PR TITLE
FLOW-2842: Handle new persistState option when navigating

### DIFF
--- a/ui-bootstrap/js/components/navigation.tsx
+++ b/ui-bootstrap/js/components/navigation.tsx
@@ -47,7 +47,7 @@ class Navigation extends React.Component<INavigationProps, null> {
 
     // Concerns navigating the Flow if the navigation
     // item clicked has not got a sub menu
-    onClick(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item: { isEnabled: boolean; id: string; }) {
+    onClick(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item: { isEnabled: boolean; id: string; }, persistState: boolean) {
 
         if (!item.isEnabled) {
             return false;
@@ -66,7 +66,7 @@ class Navigation extends React.Component<INavigationProps, null> {
             }
         });
 
-        manywho.engine.navigate(this.props.id, item.id, null, this.props.flowKey);
+        manywho.engine.navigate(this.props.id, item.id, null, this.props.flowKey, persistState);
 
         return true;
     }
@@ -115,7 +115,7 @@ class Navigation extends React.Component<INavigationProps, null> {
         return <div className="navbar-header">{children}</div>;
     }
 
-    getNavElements(items: any, isTopLevel: boolean) {
+    getNavElements(items: any, persistState: boolean, isTopLevel: boolean) {
         const elements = [];
 
         Object.keys(items).forEach((itemId) => {
@@ -145,14 +145,14 @@ class Navigation extends React.Component<INavigationProps, null> {
                             <span className="caret" />
                         </a>
                         <ul className="dropdown-menu">
-                            {this.getNavElements(item.items, false)}
+                            {this.getNavElements(item.items, persistState, false)}
                         </ul>
                     </li>
                 );
             } else {
                 element = (
                     <li className={classNames.join(' ')} key={item.id}>
-                        <a href="#" onClick={(e: React.MouseEvent<HTMLElement>) => this.onClick(e, item)} id={item.id}>
+                        <a href="#" onClick={(e: React.MouseEvent<HTMLElement>) => this.onClick(e, item, persistState)} id={item.id}>
                             {item.label}
                         </a>
                     </li>
@@ -175,7 +175,7 @@ class Navigation extends React.Component<INavigationProps, null> {
 
             manywho.log.info('Rendering Navigation');
 
-            let navElements = this.getNavElements(navigation.items, true);
+            let navElements = this.getNavElements(navigation.items, navigation.persistState, true);
 
             navElements = navElements.concat(
                 manywho.settings.global('navigation.components') || [],
@@ -247,8 +247,8 @@ class Navigation extends React.Component<INavigationProps, null> {
                                     // TODO: Use more accessible elements for navigation items
                                     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
                                     <li
-                                        onClick={(e: React.MouseEvent<HTMLElement>) => this.onClick(e, item)}
-                                        onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => this.onClick(e, item)}
+                                        onClick={(e: React.MouseEvent<HTMLElement>) => this.onClick(e, item, navigation.persistState)}
+                                        onKeyDown={(e: React.KeyboardEvent<HTMLElement>) => this.onClick(e, item, navigation.persistState)}
                                         key={item.id}
                                         id={item.id}
                                         className={className}

--- a/ui-core/js/services/engine.ts
+++ b/ui-core/js/services/engine.ts
@@ -1103,6 +1103,7 @@ export const navigate = (
     navigationElementId: string,
     mapElementId: string,
     flowKey: string,
+    persistState: boolean,
     selectedStateEntryId?: string,
 ): JQueryDeferred<any> => {
 
@@ -1114,7 +1115,8 @@ export const navigate = (
         navigationId,
         navigationElementId,
         mapElementId,
-        State.getPageComponentInputResponseRequests(flowKey),
+        // Optionally throw away any user selections/input to reduce the payload size.
+        persistState ? State.getPageComponentInputResponseRequests(flowKey) : null,
         Settings.flow('annotations', flowKey),
         State.getLocation(flowKey),
         selectedStateEntryId,

--- a/ui-core/js/services/model.ts
+++ b/ui-core/js/services/model.ts
@@ -414,6 +414,7 @@ export const parseNavigationResponse = (id: string, response, flowKey: string, c
         developerName: response.developerName,
         label: response.label,
         tags: response.tags,
+        persistState: response.persistState,
     };
 
     flowModel[lookUpKey].navigation[id].items = getNavigationItems(response.navigationItemResponses, response.navigationItemDataResponses);

--- a/ui-core/test/model.ts
+++ b/ui-core/test/model.ts
@@ -770,12 +770,14 @@ test.serial('Parse Navigation Response', (t) => {
                 isCurrent: false,
             },
         ],
+        persistState: true,
     };
 
     const expected = {
         culture: 'culture',
         developerName: 'developerName',
         label: 'label',
+        persistState: true,
         tags: 'tags',
         isVisible: true,
         isEnabled: true,


### PR DESCRIPTION
During the creation of Navigation in the tooling there is a new option to control whether to send the State payload during navigation (persistState).

This change honours that new property. The interesting part is in engine.ts `navigate()`