### PR TITLE
Feature/flow 2571

### DIFF
--- a/ui-bootstrap/js/components/mixins.ts
+++ b/ui-bootstrap/js/components/mixins.ts
@@ -20,16 +20,9 @@ import * as ReactDOM from 'react-dom';
                 && (e.target.className && e.target.className.indexOf('prevent-submit-on-enter') === -1)
                 && manywho.settings.global('shortcuts.progressOnEnter', this.props.flowKey, true)) {
 
-                const outcome = manywho.model.getOutcomes(null, this.props.flowKey)
-                    .sort(function (a, b) {
-
-                        return a.order - b.order;
-
-                    })
+                const outcome = manywho.model.getAllOutcomes(this.props.flowKey)
                     .filter(function (outcome) {
-
                         return manywho.utils.isEqual(outcome.pageActionBindingType, 'save', true);
-
                     })[0];
 
                 if (outcome) {

--- a/ui-core/js/services/model.ts
+++ b/ui-core/js/services/model.ts
@@ -543,11 +543,9 @@ export const getOutcome = (id: string, flowKey: string) => {
 };
 
 /**
- * Get all the outcomes for a container / component
- * @param id Id of the component or container that the outcomes are associated with
+ * Gets all the outcomes in the current state
  */
-export const getOutcomes = (id: string, flowKey: string): any[] => {
-
+export const getAllOutcomes = (flowKey: string): any[] => {
     const lookUpKey = Utils.getLookUpKey(flowKey);
 
     if (flowModel[lookUpKey] === undefined || flowModel[lookUpKey].outcomes === undefined) {
@@ -556,7 +554,16 @@ export const getOutcomes = (id: string, flowKey: string): any[] => {
 
     const outcomesArray = Utils.convertToArray(flowModel[lookUpKey].outcomes) || [];
 
-    outcomesArray.sort((a, b) => a.order - b.order);
+    return outcomesArray.sort((a, b) => a.order - b.order);
+};
+
+/**
+ * Get all the outcomes for a container / component
+ * @param id Id of the component or container that the outcomes are associated with
+ */
+export const getOutcomes = (id: string, flowKey: string): any[] => {
+
+    const outcomesArray = getAllOutcomes(flowKey);
 
     return outcomesArray.filter((outcome) => {
         return (!Utils.isNullOrWhitespace(id) && Utils.isEqual(outcome.pageObjectBindingId, id, true))

--- a/ui-core/test/model.ts
+++ b/ui-core/test/model.ts
@@ -965,3 +965,72 @@ test('We use the developerName if the invoke response has no label', (t) => {
     });
 
 });
+
+test('Outcomes are sorted by order', (t) => {
+    const response = {
+        invokeType: 'FORWARD',
+        mapElementInvokeResponses: [
+            {
+                outcomeResponses: [
+                    {
+                        id: 'outcome-1',
+                        pageContainerId: 'container-1',
+                        order: 1,
+                    },
+                    {
+                        id: 'outcome-2',
+                        pageContainerId: 'container-1',
+                        order: 0,
+                    },
+                ],
+            },
+        ],
+    };
+
+    Model.parseEngineResponse(response, flowKey);
+    const allOutcomes = Model.getAllOutcomes(flowKey);
+
+    t.is(allOutcomes.length, 2);
+    t.is(allOutcomes[0].id, 'outcome-2');
+    t.is(allOutcomes[1].id, 'outcome-1');
+});
+
+test('Outcomes are empty if an invalid flowkey is specified', (t) => {
+    const response = {
+        invokeType: 'FORWARD',
+        mapElementInvokeResponses: [
+            {
+                outcomeResponses: [
+                    {
+                        id: 'outcome-1',
+                        pageContainerId: 'container-1',
+                        order: 1,
+                    },
+                    {
+                        id: 'outcome-2',
+                        pageContainerId: 'container-1',
+                        order: 0,
+                    },
+                ],
+            },
+        ],
+    };
+
+    Model.parseEngineResponse(response, flowKey);
+    const allOutcomes = Model.getAllOutcomes('SOME_INCORRECT_FLOWKEY');
+    t.is(allOutcomes.length, 0);
+});
+
+test('Outcomes are empty if no outcomes were parsed in api response', (t) => {
+    const response = {
+        invokeType: 'FORWARD',
+        mapElementInvokeResponses: [
+            {
+            },
+        ],
+    };
+
+    Model.parseEngineResponse(response, flowKey);
+    const allOutcomes = Model.getAllOutcomes(flowKey);
+    t.is(allOutcomes.length, 0);
+});


### PR DESCRIPTION
The shortcuts.progressOnEnter player option enables runtime users to hit return whilst focused on an input field and for an outcome to be triggered. The current behaviour for when multiple outcomes are on the page is that the outcome ordered first from all outcomes that are either bound to the page component or not bound to any page component will be executed.

The new behaviour is that the outcome ordered first from all outcomes regardless of page component binding, will be executed.