### PR TITLE
Feature/flow 4523 - Message component modal scrolled down if advanced menu is open

### DIFF
--- a/ui-core/js/services/model.ts
+++ b/ui-core/js/services/model.ts
@@ -161,25 +161,24 @@ const checkToAutoFocus = (invokeType: string, flowKey: string) => {
         const validFieldsToFocus = ['INPUT', 'INPUT_DATETIME', 'INPUT_NUMBER', 'TEXTAREA'];
         const lookUpKey = Utils.getLookUpKey(flowKey);
 
-        // Always need to start with the root container
-        const mainContainer: Icontainer = Object.keys(flowModel[lookUpKey].containers).map((key) => {
+        // Always need to start with the root containers
+        const rootContainers: Icontainer[] = Object.keys(flowModel[lookUpKey].containers).map((key) => {
             return flowModel[lookUpKey].containers[key];
-        }).find(c => c.developerName.toUpperCase() === 'MAIN CONTAINER' && !c.parent);
+        }).filter(c => !c.parent).sort((a, b) => a.order - b.order);
 
         /**
          *
          * @param container
-         * @param flowKey
-         * @description Finds the very first component to be rendered in the flow
-         * and sets a flag for it to either autofocus or not
+         * @description Sets an autofocus flag on the very first component to be rendered in the flow
+         * and sets the flag to false for all other components
          */
-        const findFirstComponent = (container: Icontainer, flowKey: string) => {
+        const setAutoFocus = (container: Icontainer) => {
             const children = getChildren(container.id, flowKey);
             for (const child of children) {
 
                 // If the container has nested elements...
                 if (child.childCount && child.childCount > 0) {
-                    findFirstComponent(child, flowKey);
+                    setAutoFocus(child);
                 }
 
                 const isValidField = child.componentType ?
@@ -198,10 +197,11 @@ const checkToAutoFocus = (invokeType: string, flowKey: string) => {
             }
         };
 
-        // If theres no main container then it must be a step
+        // If theres no root containers then it must be a step
         // element, so no need to bother
-        if (mainContainer) {
-            findFirstComponent(mainContainer, flowKey);
+        if (rootContainers.length > 0) {
+            // Set the autoFocus flag on the containers and components
+            rootContainers.forEach(container => setAutoFocus(container));
         }
     }
 };

--- a/ui-core/test/model.ts
+++ b/ui-core/test/model.ts
@@ -127,6 +127,7 @@ test.serial('Parse Response', (t) => {
         {},
         response.mapElementInvokeResponses[0].pageResponse.pageComponentResponses[0],
         response.mapElementInvokeResponses[0].pageResponse.pageComponentDataResponses[0],
+        { autoFocus: true },
     );
     t.deepEqual(Model.getComponent('component-1', flowKey), expectedComponent);
     t.deepEqual(Model.getComponentByName('component-1', flowKey), expectedComponent);
@@ -702,6 +703,189 @@ test.serial('Auto focus gets applied to elements nested in child containers', (t
     t.is(Model.getComponentByName('component-1', flowKey).autoFocus, true);
     t.is(Model.getComponentByName('component-2', flowKey).autoFocus, false);
     t.is(Model.getComponentByName('component-3', flowKey).autoFocus, false);
+});
+
+test.serial('Auto focus gets applied to first input in first container, regardless of name', (t) => {
+    const response = {
+        parentStateId: 'parentStateId',
+        invokeType: 'FORWARD',
+        waitMessage: 'waitMessage',
+        voteResponse: 'vote',
+        mapElementInvokeResponses: [
+            {
+                pageResponse: {
+                    label: 'label',
+                    attributes: {
+                        key: 'value',
+                    },
+                    pageContainerResponses: [
+                        {
+                            containerType: 'VERTICAL_FLOW',
+                            developerName: 'main container',
+                            id: 'container-2',
+                            order: 1,
+                            pageContainerResponses: [],
+                        },
+                        {
+                            containerType: 'VERTICAL_FLOW',
+                            developerName: 'first container',
+                            id: 'container-1',
+                            order: 0,
+                            pageContainerResponses: [],
+                        },
+                    ],
+                    pageContainerDataResponses: [
+                        {
+                            isEditable: true,
+                            isEnabled: true,
+                            isVisible: true,
+                            pageContainerId: 'container-2',
+                        },
+                        {
+                            isEditable: true,
+                            isEnabled: true,
+                            isVisible: true,
+                            pageContainerId: 'container-1',
+                        },
+                    ],
+                    pageComponentResponses: [
+                        {
+                            componentType: 'INPUT',
+                            contentType: 'ContentString',
+                            developerName: 'component-1',
+                            id: 'component-1',
+                            pageContainerId: 'container-1',
+                            pageContainerDeveloperName: 'container-1',
+                            isVisible: true,
+                        },
+                        {
+                            componentType: 'INPUT',
+                            contentType: 'ContentString',
+                            developerName: 'component-2',
+                            id: 'component-2',
+                            pageContainerId: 'container-2',
+                            pageContainerDeveloperName: 'container-2',
+                            isVisible: true,
+                        },
+                    ],
+                    pageComponentDataResponses: [
+                        {
+                            contentValue: 'value',
+                            pageComponentId: 'component-1',
+                        },
+                    ],
+                },
+                outcomeResponses: [
+                    {
+                        id: 'outcome-1',
+                        pageContainerId: 'ffd48fa6-2017-4d38-9f48-b896993bb874',
+                    },
+                ],
+                rootFaults: {
+                    fault: 'fault message',
+                },
+            },
+        ],
+        preCommitStateValues: 'preCommitStateValues',
+        stateValues: 'stateValues',
+    };
+
+    Model.parseEngineResponse(response, flowKey);
+
+    t.is(Model.getComponentByName('component-1', flowKey).autoFocus, true);
+    t.is(Model.getComponentByName('component-2', flowKey).autoFocus, false);
+});
+
+test.serial('Auto focus gets applied to first input, even when it\'s not in the first container', (t) => {
+    const response = {
+        parentStateId: 'parentStateId',
+        invokeType: 'FORWARD',
+        waitMessage: 'waitMessage',
+        voteResponse: 'vote',
+        mapElementInvokeResponses: [
+            {
+                pageResponse: {
+                    label: 'label',
+                    attributes: {
+                        key: 'value',
+                    },
+                    pageContainerResponses: [
+                        {
+                            containerType: 'VERTICAL_FLOW',
+                            developerName: 'main container',
+                            id: 'container-2',
+                            order: 0,
+                            pageContainerResponses: [],
+                        },
+                        {
+                            containerType: 'VERTICAL_FLOW',
+                            developerName: 'second container',
+                            id: 'container-1',
+                            order: 1,
+                            pageContainerResponses: [],
+                        },
+                    ],
+                    pageContainerDataResponses: [
+                        {
+                            isEditable: true,
+                            isEnabled: true,
+                            isVisible: true,
+                            pageContainerId: 'container-2',
+                        },
+                        {
+                            isEditable: true,
+                            isEnabled: true,
+                            isVisible: true,
+                            pageContainerId: 'container-1',
+                        },
+                    ],
+                    pageComponentResponses: [
+                        {
+                            componentType: 'INPUT',
+                            contentType: 'ContentString',
+                            developerName: 'component-1',
+                            id: 'component-1',
+                            pageContainerId: 'container-1',
+                            pageContainerDeveloperName: 'container-1',
+                            isVisible: true,
+                        },
+                        {
+                            componentType: 'NOT_AN_INPUT',
+                            contentType: 'ContentString',
+                            developerName: 'component-2',
+                            id: 'component-2',
+                            pageContainerId: 'container-2',
+                            pageContainerDeveloperName: 'container-2',
+                            isVisible: true,
+                        },
+                    ],
+                    pageComponentDataResponses: [
+                        {
+                            contentValue: 'value',
+                            pageComponentId: 'component-1',
+                        },
+                    ],
+                },
+                outcomeResponses: [
+                    {
+                        id: 'outcome-1',
+                        pageContainerId: 'ffd48fa6-2017-4d38-9f48-b896993bb874',
+                    },
+                ],
+                rootFaults: {
+                    fault: 'fault message',
+                },
+            },
+        ],
+        preCommitStateValues: 'preCommitStateValues',
+        stateValues: 'stateValues',
+    };
+
+    Model.parseEngineResponse(response, flowKey);
+
+    t.is(Model.getComponentByName('component-1', flowKey).autoFocus, true);
+    // non-inputs should not get autofocus
+    t.is(Model.getComponentByName('component-2', flowKey).autoFocus, undefined);
 });
 
 test.serial('Notifications', (t) => {


### PR DESCRIPTION
This issue affects Message, Save and Delete components because the container containing their first input, is not called “main container”.

Due to a runtime issue, autofocus only focusses the first 'INPUT', 'INPUT_DATETIME', 'INPUT_NUMBER', 'TEXTAREA' within a root container named “main container” (case insensitive).

The system flow for these map element configs have the advanced section container named "main container", hence the issue.

In this ticket I’ll fix autofocus at runtime to focus the first valid 'INPUT', 'INPUT_DATETIME', 'INPUT_NUMBER', 'TEXTAREA' in any container, ordered by order property, and secondly by order in the metadata.