### PR TITLE
FLOW-5196 fix button size for outcomes component

### DIFF
--- a/ui-bootstrap/__tests__/outcome.test.tsx
+++ b/ui-bootstrap/__tests__/outcome.test.tsx
@@ -15,6 +15,7 @@ describe('Outcome component behaviour', () => {
             className = null,
             type = '',
             size = '',
+            propSize = null,
             pageActionType = str(),
             pageActionBindingType = null,
             classes = '',
@@ -44,7 +45,7 @@ describe('Outcome component behaviour', () => {
             };
         };
 
-        return shallow(<Outcome className={className} onClick={onClick} display={null} />);
+        return shallow(<Outcome className={className} onClick={onClick} display={null} size={propSize} />);
     }
 
     afterEach(() => {
@@ -81,6 +82,19 @@ describe('Outcome component behaviour', () => {
         });
 
         expect(componentWrapper.hasClass(`btn-${size}`)).toBe(true);
+    });
+
+    test('Component model.attributes.size overrides props.size', () => {
+        const size = str(5);
+        const propSize = str(5);
+
+        componentWrapper = manyWhoMount({
+            size,
+            propSize,
+        });
+
+        expect(componentWrapper.hasClass(`btn-${size}`)).toBe(true);
+        expect(componentWrapper.hasClass(`btn-${propSize}`)).toBe(false);
     });
 
     test('Component receives correct pageActionType CSS classes', () => {

--- a/ui-bootstrap/css/components/outcomes.less
+++ b/ui-bootstrap/css/components/outcomes.less
@@ -1,8 +1,4 @@
 .mw-bs {
-    .mw-outcomes > .row:not(.block) {
-        display: flex;
-        flex-wrap: wrap;
-    }
 
     .justify-right {
         justify-content: flex-end;

--- a/ui-bootstrap/js/components/outcome.tsx
+++ b/ui-bootstrap/js/components/outcome.tsx
@@ -113,11 +113,11 @@ class Outcome extends React.Component<IOutcomeProps, null> {
     }
 
     getSize(model) {
-        if (this.props.size)
-            return 'btn-' + this.props.size;
-
         if (model.attributes && model.attributes.size)
             return 'btn-' + model.attributes.size;
+        
+        if (this.props.size)
+            return 'btn-' + this.props.size;
 
         if (!manywho.utils.isNullOrWhitespace(model.pageObjectBindingId)) {
             const component = manywho.model.getComponent(


### PR DESCRIPTION
there were two issues here:

1. **it always had `default` class:** outcomes component passed down a button size of default because its model.attributes was empty here: https://github.com/manywho/ui-runtime/blob/eed92e41d97702f22c5e1a4e0557de1b45480279/ui-bootstrap/js/components/outcomes.tsx#L64-L66
this overrode the outcome attributes as it got checked first and quit the function here: https://github.com/manywho/ui-runtime/blob/eb1f55e8c4612dc7f86f0c9bfe877b88d6823cd1/ui-bootstrap/js/components/outcome.tsx#L119-L120
so I have swapped it so the outcome checks its attributes first before its props
2. **all classes were the same height:** now that the correct class is applied, its size was still large because `display: flex` made all the outcomes the same height. 
so I removed the display flex from the outcomes component

hopefully the display flex was not needed for anything else?
outcomes under the outcomes component now looks like the bottom instead of the top, to match outcomes under presentation and unattached outcomes
<img width="422" alt="image" src="https://user-images.githubusercontent.com/11045744/174635460-bbc3a19f-7ede-4a57-a77c-4a13101db777.png">
