### PR TITLE
FLOW-5309 revert outcome size change

### DIFF
--- a/ui-bootstrap/css/components/outcomes.less
+++ b/ui-bootstrap/css/components/outcomes.less
@@ -2,7 +2,6 @@
     .mw-outcomes > .row:not(.block) {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
     }
 
     .justify-right {


### PR DESCRIPTION
we added this to fix outcome button sizes but it broke vertically aligned outcomes (flex-flow: column)