### PR TITLE
FLOW-5306 outcome size overrides component size

### DIFF
--- a/ui-bootstrap/__tests__/outcome.test.tsx
+++ b/ui-bootstrap/__tests__/outcome.test.tsx
@@ -84,6 +84,19 @@ describe('Outcome component behaviour', () => {
         expect(componentWrapper.hasClass(`btn-${size}`)).toBe(true);
     });
 
+    test('Component model.attributes.size overrides props.size', () => {
+        const size = str(5);
+        const propSize = str(5);
+
+        componentWrapper = manyWhoMount({
+            size,
+            propSize,
+        });
+
+        expect(componentWrapper.hasClass(`btn-${size}`)).toBe(true);
+        expect(componentWrapper.hasClass(`btn-${propSize}`)).toBe(false);
+    });
+
     test('Component receives correct pageActionType CSS classes', () => {
         componentWrapper = manyWhoMount({
             pageActionType: 'import',

--- a/ui-bootstrap/js/components/outcome.tsx
+++ b/ui-bootstrap/js/components/outcome.tsx
@@ -113,11 +113,11 @@ class Outcome extends React.Component<IOutcomeProps, null> {
     }
 
     getSize(model) {
-        if (this.props.size)
-            return 'btn-' + this.props.size;
-        
         if (model.attributes && model.attributes.size)
             return 'btn-' + model.attributes.size;
+        
+        if (this.props.size)
+            return 'btn-' + this.props.size;
         
         if (!manywho.utils.isNullOrWhitespace(model.pageObjectBindingId)) {
             const component = manywho.model.getComponent(


### PR DESCRIPTION
if the button size is defined on the outcome it should override the size defined on the component it displays with.

e.g. the outcomes page component sets all its outcomes to `default` size, a "button size" defined on an individual outcome displaying with that page component will override this `default` size. Previously it was not possible to override this `default` size.

After discussing with the team, this makes sense because it works like css where the more specific selector wins.
This will have a lower impact on customers as it is not a css change that will conflict with custom players and will have no effect unless a button size is defined on the outcome itself.