### PR TITLE
FLOW-5430 - Fixing flow crashing when datetime table input is clicked…

### DIFF
--- a/ui-bootstrap/__tests__/table-input-datetime.test.tsx
+++ b/ui-bootstrap/__tests__/table-input-datetime.test.tsx
@@ -34,7 +34,7 @@ describe('Table Input Datetime component behaviour', () => {
     let tableInputDatetimeWrapper;
     let props;
 
-    function manyWhoMount(value = null, isShallow = false, format = str(10), contentFormat = null) {
+    function manyWhoMount(value = null, isShallow = false, format = str(10)) {
         props = {
             value,
             format,
@@ -44,7 +44,6 @@ describe('Table Input Datetime component behaviour', () => {
             onChange: jest.fn(() => {
                 return true;
             }),
-            contentFormat,
         };
 
         if (isShallow === false)
@@ -84,7 +83,7 @@ describe('Table Input Datetime component behaviour', () => {
             useCurrent: false,
         };
 
-        tableInputDatetimeWrapper = manyWhoMount('07-12-1986', true, null, 'MM-DD-YYYY');
+        tableInputDatetimeWrapper = manyWhoMount('07-12-1986', true, 'MM-DD-YYYY');
         expect(globalAny.datetimepickerMock).toHaveBeenCalledWith(
             expectedArgs,
         ); 

--- a/ui-bootstrap/js/components/table-input-datetime.tsx
+++ b/ui-bootstrap/js/components/table-input-datetime.tsx
@@ -3,13 +3,13 @@ import { findDOMNode } from 'react-dom';
 import * as $ from 'jquery';
 import * as moment from 'moment';
 import registeredComponents from '../constants/registeredComponents';
-import ITableInputDateTimeProps from '../interfaces/ITableInputDateTimeProps';
+import TableInputDateTimeProps from '../interfaces/ITableInputDateTimeProps';
 
 import '../lib/100-datetimepicker.js';
 
 declare var manywho: any;
 
-class TableInputDateTime extends React.Component<ITableInputDateTimeProps, null> {
+class TableInputDateTime extends React.Component<TableInputDateTimeProps, null> {
 
     datetime = null;
 
@@ -31,7 +31,7 @@ class TableInputDateTime extends React.Component<ITableInputDateTimeProps, null>
             this.props.value ? 
             moment(
                 this.props.value, 
-                [this.props.contentFormat || '', 'MM/DD/YYYY hh:mm:ss A ZZ', moment.ISO_8601],
+                [this.props.format || '', 'MM/DD/YYYY hh:mm:ss A ZZ', moment.ISO_8601],
             ) : 
             null;
 

--- a/ui-bootstrap/js/interfaces/ITableInputDateTimeProps.ts
+++ b/ui-bootstrap/js/interfaces/ITableInputDateTimeProps.ts
@@ -1,10 +1,9 @@
 import * as React from 'react';
 
-interface ITableInputDateTimeProps {
+interface TableInputDateTimeProps {
     onChange: (event: React.SyntheticEvent<HTMLElement>) => void;
     format: string;
     value: string;
-    contentFormat?: string;
 }
 
-export default ITableInputDateTimeProps;
+export default TableInputDateTimeProps;


### PR DESCRIPTION
… to toggle the date picker.

An undefined prop was being used to specify a custom date format when creating the moment object causing the flow page to crash. Test and interface have been adjusted to accommodate this change.