### PR TITLE
FLOW-1501 - Fixng the time from decrementing by an hour every time th…

### DIFF
--- a/ui-bootstrap/js/components/input-datetime.tsx
+++ b/ui-bootstrap/js/components/input-datetime.tsx
@@ -76,9 +76,6 @@ class InputDateTime extends React.Component<IInputProps, null> {
     }
 
     setPickerDate(newDate) {
-        const datepickerElement = findDOMNode(this.refs['datepicker']);
-        const datepickerInstance = $(datepickerElement).data('DateTimePicker');
-
         let date = moment(
             newDate,
             [
@@ -95,22 +92,22 @@ class InputDateTime extends React.Component<IInputProps, null> {
         );
 
         if (newDate === null) {
-            datepickerInstance.date(null);
+            return null;
         } else if (this.isDateOnly) {
             // Create a new date with no time information
 
             // With a Date only input box, we do not show time,
             // so we do not want timezones and so use utc
-            datepickerInstance.date(UTCdate);
+            return UTCdate;
 
         } else {
 
             if (
                 manywho.settings.global('i18n.overrideTimezoneOffset', this.props.flowKey)
             ) {
-                datepickerInstance.date(date.local());
+                return date.local();
             } else {
-                datepickerInstance.date(UTCdate);
+                return UTCdate;
             }
         }
     }
@@ -159,6 +156,7 @@ class InputDateTime extends React.Component<IInputProps, null> {
                 manywho.formatting.toMomentFormat(model.contentFormat) ||
                 'MM/DD/YYYY',
             timeZone: 'UTC',
+            date: this.setPickerDate(this.props.value),
         })
             .on('dp.change', !this.props.isDesignTime && this.onChange);
 
@@ -167,8 +165,6 @@ class InputDateTime extends React.Component<IInputProps, null> {
         if (model.autoFocus) {
             $(datepickerElement).data('DateTimePicker').show();
         }
-
-        this.setPickerDate(this.props.value);
     }
 
     componentWillUnmount() {
@@ -177,10 +173,11 @@ class InputDateTime extends React.Component<IInputProps, null> {
     }
 
     componentDidUpdate() {
-        const newDate = this.props.value === ''
-            ? null
-            : this.props.value;
-        this.setPickerDate(newDate);
+        if (this.props.value === '') {
+            const datepickerElement = findDOMNode(this.refs['datepicker']);
+            const datepickerInstance = $(datepickerElement).data('DateTimePicker');
+            datepickerInstance.clear();
+        }
     }
 
     render() {

--- a/ui-bootstrap/js/components/input-datetime.tsx
+++ b/ui-bootstrap/js/components/input-datetime.tsx
@@ -173,7 +173,9 @@ class InputDateTime extends React.Component<IInputProps, null> {
     }
 
     componentDidUpdate() {
-        if (this.props.value === '') {
+        // This makes sure that the date value gets cleared from the input field when
+        // it's visibility is toggled using a page condition
+        if (!this.props.value) {
             const datepickerElement = findDOMNode(this.refs['datepicker']);
             const datepickerInstance = $(datepickerElement).data('DateTimePicker');
             datepickerInstance.clear();


### PR DESCRIPTION
…e datetime picker is opened.

So in `setPickerDate` we were setting the date on the Bootstrap datepicker instance which caused the `onChange` function to fire in the background, including every time the date picker was opened by clicking the input. Since `onChange` by default will set the UTC date in state, this caused the time displayed to decrement by an hour since GMT BST is an hour ahead of UTC. 