### PR TITLE
Flow 5788 Fixing issue with Datetime Input binding

### DIFF
--- a/ui-bootstrap/__tests__/input-datetime.test.tsx
+++ b/ui-bootstrap/__tests__/input-datetime.test.tsx
@@ -114,30 +114,30 @@ describe('InputDateTime component behaviour', () => {
     // This tests the scenario whereby a page condition triggers the date input to be
     // hidden then reappear. In which case the input value needs to be cleared.
     test('If the component updates with a falsey value prop then clear the date pickers contents', () => {
-        const mockSetPickerDate = jest.spyOn(InputDateTime.prototype, 'setPickerDate');
+        const mockSetGetDate = jest.spyOn(InputDateTime.prototype, 'getDate');
 
         componentWrapper = manyWhoMount(false, false, 'YYYY/MM/DD', '2018/12/25');
-        expect(mockSetPickerDate).toHaveBeenCalledWith('2018/12/25');
+        expect(mockSetGetDate).toHaveBeenCalledWith('2018/12/25');
 
         componentWrapper.setProps({ value: null });
         expect(mockClear).toHaveBeenCalled();
     });
 
     test('make sure backspace doesn\'t clear input', () => {
-        const mockSetPickerDate = jest.spyOn(InputDateTime.prototype, 'setPickerDate');
+        const mockSetGetDate = jest.spyOn(InputDateTime.prototype, 'getDate');
 
         componentWrapper = manyWhoMount(false, false, 'DD/MM/YYYY', '25/12/2018');
-        expect(mockSetPickerDate).toHaveBeenCalledWith('25/12/2018');
+        expect(mockSetGetDate).toHaveBeenCalledWith('25/12/2018');
 
         componentWrapper.find(InputDateTime).simulate('keydown', {keyCode: 8});
         expect(componentWrapper.find(InputDateTime).props().value).toBeTruthy();
     });
 
-    test('setPickerDate is called with correct date value', () => {
-        const mockSetPickerDate = jest.spyOn(InputDateTime.prototype, 'setPickerDate');
+    test('getDate is called with correct date value', () => {
+        const mockSetGetDate = jest.spyOn(InputDateTime.prototype, 'getDate');
 
         componentWrapper = manyWhoMount(false, false, 'YYYY/MM/DD', '2018/12/25');
-        expect(mockSetPickerDate).toHaveBeenCalledWith('2018/12/25');
+        expect(mockSetGetDate).toHaveBeenCalledWith('2018/12/25');
     });
 
     // By default the date time picker should display it's content value in UTC

--- a/ui-bootstrap/js/components/input-datetime.tsx
+++ b/ui-bootstrap/js/components/input-datetime.tsx
@@ -75,15 +75,17 @@ class InputDateTime extends React.Component<IInputProps, null> {
         }
     }
 
-    setPickerDate(newDate) {
-        let date = moment(
+    // eslint-disable-next-line react/sort-comp
+    getDate(newDate): moment.Moment
+    {
+        const date = moment(
             newDate,
             [
                 'MM/DD/YYYY hh:mm:ss A ZZ', 'YYYY-MM-DDTHH:mm:ss.SSSSSSSZ',
                 moment.ISO_8601,
             ],
         );
-        let UTCdate = moment.utc(
+        const UTCdate = moment.utc(
             newDate,
             [
                 'MM/DD/YYYY hh:mm:ss A ZZ', 'YYYY-MM-DDTHH:mm:ss.SSSSSSSZ',
@@ -112,7 +114,15 @@ class InputDateTime extends React.Component<IInputProps, null> {
         }
     }
 
-    componentDidMount() {
+    setPickerDate(newDate): void {
+        const datepickerElement = findDOMNode(this.refs['datepicker']);
+        const datepickerInstance = $(datepickerElement).data('DateTimePicker');
+
+        const date = this.getDate(newDate);
+        datepickerInstance.date(date);
+    }
+
+    componentDidMount(): void {
         const model = manywho.model.getComponent(this.props.id, this.props.flowKey);
 
         let useCurrent = false;
@@ -156,7 +166,7 @@ class InputDateTime extends React.Component<IInputProps, null> {
                 manywho.formatting.toMomentFormat(model.contentFormat) ||
                 'MM/DD/YYYY',
             timeZone: 'UTC',
-            date: this.setPickerDate(this.props.value),
+            date: this.getDate(this.props.value),
         })
             .on('dp.change', !this.props.isDesignTime && this.onChange);
 
@@ -179,6 +189,11 @@ class InputDateTime extends React.Component<IInputProps, null> {
             const datepickerElement = findDOMNode(this.refs['datepicker']);
             const datepickerInstance = $(datepickerElement).data('DateTimePicker');
             datepickerInstance.clear();
+        } else {
+            const newDate = this.props.value === ''
+                ? null
+                : this.props.value;
+            this.setPickerDate(newDate);
         }
     }
 

--- a/ui-bootstrap/js/components/input-datetime.tsx
+++ b/ui-bootstrap/js/components/input-datetime.tsx
@@ -75,8 +75,8 @@ class InputDateTime extends React.Component<IInputProps, null> {
         }
     }
 
-    // eslint-disable-next-line react/sort-comp
-    getDate(newDate): moment.Moment
+
+    getDate(newDate)
     {
         const date = moment(
             newDate,


### PR DESCRIPTION
If a flow is created where the page doesn't unmount then the datetime input wouldn't populate correctly. This should fix that issue while maintaining the previous change made in https://boomii.atlassian.net/browse/FLOW-1501