### PR TITLE
FLOW-5888 Add new modal map element

### DIFF
--- a/ui-bootstrap/__tests__/main.test.tsx
+++ b/ui-bootstrap/__tests__/main.test.tsx
@@ -3,9 +3,11 @@ import { shallow } from 'enzyme';
 
 import Main from '../js/components/main';
 
+window.manywho.model.getModalPage = () => null;
+
 describe('Main component behaviour', () => {
 
-    const globalAny:any = global;
+    const globalAny: any = global;
 
     test('Component renders without crashing', () => {
         expect(shallow(<Main />).length).toEqual(1);

--- a/ui-bootstrap/__tests__/modal-container.test.tsx
+++ b/ui-bootstrap/__tests__/modal-container.test.tsx
@@ -140,38 +140,42 @@ describe('ModalContainer component behaviour', () => {
     test('Modal map element content is conditionally rendered', () => {
         const onClose = jest.fn();
         window.manywho.model.setModal = jest.fn();
+        window.manywho.utils.isNullOrEmpty = jest.fn(
+          (input) =>
+            typeof input === "undefined" || input === null || input === ""
+        );
 
         const props1 = {
-            flowKey: 'zzz'
+          flowKey: "111",
         };
 
         const props2 = {
-            flowKey: 'zzz',
-            onClose,
-            title: 'Test Title',
-            modalClasses: 'test-class',
+          flowKey: "222",
+          onClose,
+          title: "Test Title",
+          modalClasses: "test-class",
         };
-        
+
         const wrapper1 = shallow(<ModalContainer {...props1} />);
-        expect(wrapper1.exists('.modal-header')).toBe(true);
-        expect(wrapper1.exists('.close')).toBe(false);
-        expect(wrapper1.exists('.modal-dialog.test-class')).toBe(false);
-        wrapper1.simulate('keyup', { 
-            keyCode: 27,
-        })
+        expect(wrapper1.exists(".modal-header")).toBe(false);
+        expect(wrapper1.exists(".close")).toBe(false);
+        expect(wrapper1.exists(".modal-dialog.test-class")).toBe(false);
+        wrapper1.simulate("keyup", {
+          keyCode: 27,
+        });
         expect(onClose).not.toHaveBeenCalled();
-        expect(window.manywho.model.setModal).toHaveBeenCalledWith('zzz', null);
+        expect(window.manywho.model.setModal).toHaveBeenCalledWith("111", null);
         window.manywho.model.setModal.mockClear();
 
         const wrapper2 = shallow(<ModalContainer {...props2} />);
-        expect(wrapper1.exists('.modal-header')).toBe(true);
-        expect(wrapper2.exists('.close')).toBe(true);
-        expect(wrapper2.exists('.modal-dialog.test-class')).toBe(true);
-        wrapper2.simulate('keyup', { 
-            keyCode: 27,
-        })
+        expect(wrapper2.exists(".modal-header")).toBe(true);
+        expect(wrapper2.exists(".close")).toBe(true);
+        expect(wrapper2.exists(".modal-dialog.test-class")).toBe(true);
+        wrapper2.simulate("keyup", {
+          keyCode: 27,
+        });
         expect(onClose).toHaveBeenCalled();
-        expect(window.manywho.model.setModal).toHaveBeenCalledWith('zzz', null);
+        expect(window.manywho.model.setModal).toHaveBeenCalledWith("222", null);
 
     });
 

--- a/ui-bootstrap/__tests__/modal-container.test.tsx
+++ b/ui-bootstrap/__tests__/modal-container.test.tsx
@@ -137,4 +137,42 @@ describe('ModalContainer component behaviour', () => {
         expect(wrapper3.exists('.btn-primary')).toBe(false);
     });
 
+    test('Modal map element content is conditionally rendered', () => {
+        const onClose = jest.fn();
+        window.manywho.model.setModal = jest.fn();
+
+        const props1 = {
+            flowKey: 'zzz'
+        };
+
+        const props2 = {
+            flowKey: 'zzz',
+            onClose,
+            title: 'Test Title',
+            modalClasses: 'test-class',
+        };
+        
+        const wrapper1 = shallow(<ModalContainer {...props1} />);
+        expect(wrapper1.exists('.modal-header')).toBe(true);
+        expect(wrapper1.exists('.close')).toBe(false);
+        expect(wrapper1.exists('.modal-dialog.test-class')).toBe(false);
+        wrapper1.simulate('keyup', { 
+            keyCode: 27,
+        })
+        expect(onClose).not.toHaveBeenCalled();
+        expect(window.manywho.model.setModal).toHaveBeenCalledWith('zzz', null);
+        window.manywho.model.setModal.mockClear();
+
+        const wrapper2 = shallow(<ModalContainer {...props2} />);
+        expect(wrapper1.exists('.modal-header')).toBe(true);
+        expect(wrapper2.exists('.close')).toBe(true);
+        expect(wrapper2.exists('.modal-dialog.test-class')).toBe(true);
+        wrapper2.simulate('keyup', { 
+            keyCode: 27,
+        })
+        expect(onClose).toHaveBeenCalled();
+        expect(window.manywho.model.setModal).toHaveBeenCalledWith('zzz', null);
+
+    });
+
 });

--- a/ui-bootstrap/__tests__/table-container.test.tsx
+++ b/ui-bootstrap/__tests__/table-container.test.tsx
@@ -124,6 +124,7 @@ describe('Table component behaviour', () => {
         });
         globalAny.window.manywho.component.getDisplayColumns = jest.fn(columns => columns);
         globalAny.window.manywho.styling.getClasses = jest.fn(() => [model.attributes.classes]);
+        globalAny.window.manywho.model.getModalPage = jest.fn(() => null);
 
         return shallow(<Table {...props} />, { disableLifecycleMethods: true });
     }

--- a/ui-bootstrap/css/components/containers.less
+++ b/ui-bootstrap/css/components/containers.less
@@ -115,6 +115,10 @@ body {
         margin-top: 0;
     }
 
+    &#modal-map-element .modal-body {
+        min-height: 0;
+    }
+
     .row {
         margin-left: 0 !important;
         margin-right: 0 !important;

--- a/ui-bootstrap/css/components/containers.less
+++ b/ui-bootstrap/css/components/containers.less
@@ -97,6 +97,7 @@ body {
         margin-top: @container-margin;
     }
 
+    &#modal-map-element .main,
     .main-empty:nth-of-type(1) {
         margin-bottom: 0;
         margin-top: 0;

--- a/ui-bootstrap/css/components/containers.less
+++ b/ui-bootstrap/css/components/containers.less
@@ -97,6 +97,18 @@ body {
         margin-top: @container-margin;
     }
 
+    &#modal-map-element {
+        background: none;
+    }
+
+    &#modal-map-element .main-scroller {
+        max-height: calc(100vh - 220px);
+    }
+
+    &#modal-map-element .main {
+        width: 100%;
+    }
+
     &#modal-map-element .main,
     .main-empty:nth-of-type(1) {
         margin-bottom: 0;

--- a/ui-bootstrap/css/components/footer.less
+++ b/ui-bootstrap/css/components/footer.less
@@ -19,4 +19,8 @@
         margin-right: 0;
     }
 
+    &#modal-map-element .mw-footer .outcome {
+        margin-bottom: 1px !important;
+    }
+
 }

--- a/ui-bootstrap/js/components/main.tsx
+++ b/ui-bootstrap/js/components/main.tsx
@@ -94,6 +94,9 @@ class Main extends React.Component<any, any> {
 
         if (attributes != null && typeof attributes.outcomes !== 'undefined')
             isFixedFooter = manywho.utils.isEqual(attributes.outcomes, 'fixed', false);
+        
+        if (manywho.model.getModalPage(this.props.flowKey))
+            isFixedFooter = true;
 
         if (isFixedFooter) {
             fixedFooter = <Footer flowKey={ this.props.flowKey }>

--- a/ui-bootstrap/js/components/modal-container.tsx
+++ b/ui-bootstrap/js/components/modal-container.tsx
@@ -27,10 +27,8 @@ const ModalContainer: React.SFC<IModalContainerProps> = ({
     }
 
     React.useEffect(() => {
-        console.log('add');
         document.addEventListener('keyup', onKeyUp);
         return () => {
-            console.log('remove');
             document.removeEventListener('keyup', onKeyUp);
         };
     }, []);

--- a/ui-bootstrap/js/components/modal-container.tsx
+++ b/ui-bootstrap/js/components/modal-container.tsx
@@ -12,12 +12,28 @@ const ModalContainer: React.SFC<IModalContainerProps> = ({
     onCancel,
     confirmLabel,
     cancelLabel,
+    onClose,
 }) => {
 
     const onKeyUp = (e) => {
-        if (e.keyCode === 27)
-            manywho.model.setModal(flowKey, null);
+        if (e.keyCode === 27) {
+            if (onClose) {
+                onClose();
+            }
+            if (manywho.model.getModal(flowKey)) {
+                manywho.model.setModal(flowKey, null);
+            }
+        }
     }
+
+    React.useEffect(() => {
+        console.log('add');
+        document.addEventListener('keyup', onKeyUp);
+        return () => {
+            console.log('remove');
+            document.removeEventListener('keyup', onKeyUp);
+        };
+    }, []);
 
     // This is not desired behaviour and will be removed
     const onClickBackdrop = (e) => {
@@ -30,7 +46,8 @@ const ModalContainer: React.SFC<IModalContainerProps> = ({
     if (!manywho.utils.isNullOrEmpty(title)) {
         header = (
             <div className="modal-header">
-                <div className="modal-title">{title}</div>
+                {onClose && <button type="button" onClick={onClose} className="close" title="close" data-dismiss="modal" aria-hidden="true">&times;</button>}
+                <h4 className="modal-title">{title}</h4>
             </div>
         );
     }

--- a/ui-bootstrap/js/components/modal-container.tsx
+++ b/ui-bootstrap/js/components/modal-container.tsx
@@ -40,7 +40,7 @@ const ModalContainer: React.SFC<IModalContainerProps> = ({
     let header = null;
     let footer = null;
 
-    if (!manywho.utils.isNullOrEmpty(title)) {
+    if (!manywho.utils.isNullOrEmpty(title) || !manywho.utils.isNullOrEmpty(onClose)) {
         header = (
             <div className="modal-header">
                 {onClose && <button type="button" onClick={onClose} className="close" title="close" data-dismiss="modal" aria-hidden="true">&times;</button>}

--- a/ui-bootstrap/js/components/modal-container.tsx
+++ b/ui-bootstrap/js/components/modal-container.tsx
@@ -13,6 +13,7 @@ const ModalContainer: React.SFC<IModalContainerProps> = ({
     confirmLabel,
     cancelLabel,
     onClose,
+    modalClasses,
 }) => {
 
     const onKeyUp = (e) => {
@@ -20,9 +21,7 @@ const ModalContainer: React.SFC<IModalContainerProps> = ({
             if (onClose) {
                 onClose();
             }
-            if (manywho.model.getModal(flowKey)) {
-                manywho.model.setModal(flowKey, null);
-            }
+            manywho.model.setModal(flowKey, null);
         }
     }
 
@@ -75,7 +74,7 @@ const ModalContainer: React.SFC<IModalContainerProps> = ({
         <div onKeyUp={onKeyUp}>
             <div className="modal-backdrop full-height" onClick={onClickBackdrop} />
             <div className="modal show">
-                <div className="modal-dialog">
+                <div className={"modal-dialog " + modalClasses}>
                     <div className="modal-content">
                         {header}
                         <div className="modal-body">

--- a/ui-bootstrap/js/components/table-container.tsx
+++ b/ui-bootstrap/js/components/table-container.tsx
@@ -150,7 +150,10 @@ class Table extends React.Component<ITableContainerProps, ITableContainerState> 
     }
 
     handleResize() {
-
+        if (manywho.model.getModalPage(this.props.flowKey)) {
+            // prevent base page from rerendering while modal is open
+            return;
+        }
         if ((this.state.windowWidth <= 768 && window.innerWidth > 768)
             || (this.state.windowWidth > 768 && window.innerWidth <= 768)) {
 

--- a/ui-bootstrap/js/interfaces/IModalContainerProps.ts
+++ b/ui-bootstrap/js/interfaces/IModalContainerProps.ts
@@ -8,6 +8,7 @@ interface IModalContainerProps extends IComponentProps {
     cancelLabel?: string;
     confirmLabel?: string;
     onClose?: any;
+    modalClasses?: string;
 }
 
 export default IModalContainerProps;

--- a/ui-bootstrap/js/interfaces/IModalContainerProps.ts
+++ b/ui-bootstrap/js/interfaces/IModalContainerProps.ts
@@ -7,6 +7,7 @@ interface IModalContainerProps extends IComponentProps {
     onCancel: any;
     cancelLabel?: string;
     confirmLabel?: string;
+    onClose?: any;
 }
 
 export default IModalContainerProps;

--- a/ui-core/js/services/engine.ts
+++ b/ui-core/js/services/engine.ts
@@ -1648,6 +1648,46 @@ export const render = (flowKey: string) => {
     );
   }
 
+  const renderModal = (modalContainer) => {
+    ReactDOM.render(
+      React.createElement(Component.getByName("modal-container"), {
+        flowKey,
+        title: modalPage?.title,
+        onClose: backOutcome ? useBackOutcomeOnBack : null,
+      }),
+      modalContainer
+    );
+    // Set the main container inside the modal
+    container = modalContainer?.querySelector(".modal-body") ?? null;
+  };
+
+  // Render inside of a modal
+  const modalPage = Model.getModalPage(flowKey);
+  const modalContainerName = "modal-map-element";
+  let modalContainer = document.getElementById(modalContainerName);
+  if (modalPage) {
+    container = modalContainer?.querySelector(".modal-body") ?? null;
+    if (!container) {
+      // Remove the loader from the base page
+      document.querySelector(".wait-container")?.classList.add("hidden");
+
+      // Add a div#modal-map-element to wrap the modal-container component
+      modalContainer = document.createElement("div");
+      modalContainer.setAttribute("id", modalContainerName);
+      modalContainer.className = "mw-bs flow-container modal-container";
+      const manywhoContainer = document.querySelector(
+        Settings.global("containerSelector", flowKey, "#manywho")
+      );
+      manywhoContainer.prepend(modalContainer);
+    }
+    renderModal(modalContainer);
+  } else {
+    // Unmount modal
+    if (modalContainer) {
+      ReactDOM.unmountComponentAtNode(modalContainer);
+    }
+  }
+
   // Bail here if there is no container.
   if (!container) {
     return;
@@ -1668,6 +1708,7 @@ export const render = (flowKey: string) => {
       container
     );
   } else {
+    console.log(`%c BFTEST rendering ${JSON.stringify(modalPage)} ${Utils.extractElement(flowKey)} in #${container.id}`, 'background: #222; color: #bada55');
     ReactDOM.render(
       React.createElement(Component.getByName(Utils.extractElement(flowKey)), {
         flowKey,

--- a/ui-core/js/services/engine.ts
+++ b/ui-core/js/services/engine.ts
@@ -1678,7 +1678,7 @@ export const render = (flowKey: string) => {
       const manywhoContainer = document.querySelector(
         Settings.global("containerSelector", flowKey, "#manywho")
       );
-      manywhoContainer.append(modalContainer);
+      manywhoContainer.appendChild(modalContainer);
     }
     renderModal();
   } else {

--- a/ui-core/js/services/engine.ts
+++ b/ui-core/js/services/engine.ts
@@ -1708,7 +1708,6 @@ export const render = (flowKey: string) => {
       container
     );
   } else {
-    console.log(`%c BFTEST rendering ${JSON.stringify(modalPage)} ${Utils.extractElement(flowKey)} in #${container.id}`, 'background: #222; color: #bada55');
     ReactDOM.render(
       React.createElement(Component.getByName(Utils.extractElement(flowKey)), {
         flowKey,

--- a/ui-core/js/services/engine.ts
+++ b/ui-core/js/services/engine.ts
@@ -1648,12 +1648,13 @@ export const render = (flowKey: string) => {
     );
   }
 
-  const renderModal = (modalContainer) => {
+  const renderModal = () => {
     ReactDOM.render(
       React.createElement(Component.getByName("modal-container"), {
         flowKey,
         title: modalPage?.title,
         onClose: backOutcome ? useBackOutcomeOnBack : null,
+        modalClasses: 'modal-lg',
       }),
       modalContainer
     );
@@ -1661,12 +1662,12 @@ export const render = (flowKey: string) => {
     container = modalContainer?.querySelector(".modal-body") ?? null;
   };
 
-  // Render inside of a modal
   const modalPage = Model.getModalPage(flowKey);
   const modalContainerName = "modal-map-element";
   let modalContainer = document.getElementById(modalContainerName);
+  // Render inside of a modal
   if (modalPage) {
-    if (!modalContainer?.querySelector(".modal-body")) {
+    if (!modalContainer) {
       // Remove the loader from the base page
       document.querySelector(".wait-container")?.classList.add("hidden");
 
@@ -1677,13 +1678,14 @@ export const render = (flowKey: string) => {
       const manywhoContainer = document.querySelector(
         Settings.global("containerSelector", flowKey, "#manywho")
       );
-      manywhoContainer.prepend(modalContainer);
+      manywhoContainer.append(modalContainer);
     }
-    renderModal(modalContainer);
+    renderModal();
   } else {
     // Unmount modal
     if (modalContainer) {
       ReactDOM.unmountComponentAtNode(modalContainer);
+      modalContainer.remove();
     }
   }
 

--- a/ui-core/js/services/engine.ts
+++ b/ui-core/js/services/engine.ts
@@ -1666,8 +1666,7 @@ export const render = (flowKey: string) => {
   const modalContainerName = "modal-map-element";
   let modalContainer = document.getElementById(modalContainerName);
   if (modalPage) {
-    container = modalContainer?.querySelector(".modal-body") ?? null;
-    if (!container) {
+    if (!modalContainer?.querySelector(".modal-body")) {
       // Remove the loader from the base page
       document.querySelector(".wait-container")?.classList.add("hidden");
 

--- a/ui-core/js/services/model.ts
+++ b/ui-core/js/services/model.ts
@@ -232,6 +232,7 @@ export const parseEngineResponse = (engineInvokeResponse, flowKey: string) => {
     flowModel[lookUpKey].stateValues = [];
     flowModel[lookUpKey].preCommitStateValues = [];
     flowModel[lookUpKey].mapElement = {};
+    flowModel[lookUpKey].modalPage = null;
 
     flowModel[lookUpKey].rootFaults = [];
 
@@ -249,6 +250,11 @@ export const parseEngineResponse = (engineInvokeResponse, flowKey: string) => {
         flowModel[lookUpKey].waitMessage = engineInvokeResponse.notAuthorizedMessage || engineInvokeResponse.waitMessage;
         flowModel[lookUpKey].vote = engineInvokeResponse.voteResponse || null;
         flowModel[lookUpKey].waitExpiresAt = engineInvokeResponse.waitExpiresAt || null;
+        if (engineInvokeResponse.pageType === 1) {
+            flowModel[lookUpKey].modalPage = {
+                title: engineInvokeResponse.title
+            };
+        }
 
         if (engineInvokeResponse.mapElementInvokeResponses[0].pageResponse) {
 
@@ -1013,4 +1019,12 @@ export const setModal = (flowKey: string, modal) => {
 export const getModal = (flowKey: string) => {
     const lookUpKey = Utils.getLookUpKey(flowKey);
     return flowModel[lookUpKey].modal;
+};
+
+/**
+ * Contains the title of a modal map element
+ */
+ export const getModalPage = (flowKey: string) => {
+    const lookUpKey = Utils.getLookUpKey(flowKey);
+    return flowModel[lookUpKey].modalPage;
 };

--- a/ui-core/test/engine.ts
+++ b/ui-core/test/engine.ts
@@ -129,6 +129,8 @@ test.beforeEach((t) => {
     const container = document.createElement('div');
     container.id = 'manywho';
     document.body.appendChild(container);
+    
+    model.getModalPage.returns(null);
 });
 
 test.afterEach((t) => {
@@ -459,6 +461,27 @@ test.serial('Render', (t) => {
     t.deepEqual(react.createElement.args[0][0], Component.getByName('main'));
 
     sinon.stub(Engine, 'render');
+});
+
+test.serial("Render in a modal", (t) => {
+  const container = document.createElement("div");
+  container.id = Utils.getLookUpKey(flowKey);
+  document.querySelector("#manywho").appendChild(container);
+
+  (Engine.render as sinon.SinonStub).restore();
+  model.getModalPage.returns({ title: "Test Title" });
+
+  Engine.render(flowKey);
+
+  // Tests up until "Bail here if there is no container."
+  t.true(ReactDOM.render.calledOnce);
+  t.true(react.createElement.calledOnce);
+  t.deepEqual(
+    react.createElement.args[0][0],
+    Component.getByName("modal-container")
+  );
+
+  sinon.stub(Engine, "render");
 });
 
 test.serial('Render Login', (t) => {

--- a/ui-core/test/engine.ts
+++ b/ui-core/test/engine.ts
@@ -54,6 +54,7 @@ const model = {
     getDefaultNavigationId: sinon.stub(),
     getOutcome: sinon.stub(),
     parseNavigationResponse: sinon.stub(),
+    getModalPage: sinon.stub(),
 };
 
 const social = {


### PR DESCRIPTION
AC from epic:
- modals appear over the top of the previous page in a pop up
- modals have a title, which appears at the top of the modal
- modals show a page, which appears in the body of the modal
- modals can be closed with an x button in the top right which follows a “back” outcome
- outcomes from the modal appear in the modal footer

Implementation:
- Uses the existing modal container `ui-bootstrap/js/components/modal-container.tsx` (previously used for editable tables) as a wrapper for the modal page.
- The wrapper is conditionally rendered in render() in `ui-core/js/services/engine.ts`
- Whether the modal page is open is controlled by getModalPage in `ui-core/js/services/model.ts` which gets set from the invoke response.